### PR TITLE
Change Switch Pro controller mapping to match Xbox layout

### DIFF
--- a/hiddriver/main.cpp
+++ b/hiddriver/main.cpp
@@ -153,8 +153,8 @@ struct switch_pro_input_report {
 
 // buttons1
 // Face buttons
-#define SWITCH_BTN_Y        (1 << 0)
-#define SWITCH_BTN_X        (1 << 1)
+#define SWITCH_BTN_Y        (1 << 1)
+#define SWITCH_BTN_X        (1 << 0)
 #define SWITCH_BTN_B        (1 << 2)
 #define SWITCH_BTN_A        (1 << 3)
 


### PR DESCRIPTION
Quick fix for the mapping of the face buttons on Nintendo Switch Pro controllers, [as mentioned by u/Impressive-Sale-4843](https://www.reddit.com/r/360hacks/s/d2wmHN0zu3). The current state is:

Right -> B button (Xbox layout)
Bottom -> A button (Xbox layout)
Left -> Y button (Switch layout)
Top -> X button (Switch layout)
(all others are consistent)

This patch swaps over left and top buttons so that they all follow the Xbox layout instead. Tested & seems to work.